### PR TITLE
A fix for [[Home]]

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -181,7 +181,7 @@ function preprocessMarkdown ( markdown, homePath ) {
 	});
 
 	// specially treat [[Home]] link
-	markdown = markdown.replace( '[[Home]]', '[Home](' + homePath + ')' );
+	markdown = markdown.replace( /\[\[Home\]\]/g, '[Home](' + homePath + ')' );
 
 	// turn [[My link]] into [My link](my-link)
 	markdown = markdown.replace( /\[\[([^\]]+)\]\]/g, function ( match, link ) {


### PR DESCRIPTION
Switched to regex to perform global replace, otherwise only the first occurrence of [[Home]] would be handled.
