### PR TITLE
Typo for JavaScript keyword 'function'

### DIFF
--- a/docs/0.4.0/Two-way binding.md.hbs
+++ b/docs/0.4.0/Two-way binding.md.hbs
@@ -97,7 +97,7 @@ var ractive = new Ractive({
 	}
 });
 
-ractive.observe('content', funciton(newValue, oldValue, keypath) {
+ractive.observe('content', function(newValue, oldValue, keypath) {
 	//newValue will contain the new content of the div
 });
 ```


### PR DESCRIPTION
Fix tiny typo.
