### PR TITLE
fix bug in boxAdaptor code sample

### DIFF
--- a/docs/0.4.0/Writing adaptor plugins.md.hbs
+++ b/docs/0.4.0/Writing adaptor plugins.md.hbs
@@ -174,7 +174,7 @@ boxAdaptor = {
         }
 
         if ( data.height !== undefined ) {
-          box.height = width;
+          box.height = height;
         }
       }
     };


### PR DESCRIPTION
still, `width` and `height` seem to be undefined, maybe they should be `data.width` and `data.height`?
I don't know how to run that part of the adaptor code in the [JSFiddle](http://jsfiddle.net/rich_harris/ATAgH/) without deleting L169, so I'm not sure how it's supposed to work.
