### PR TITLE
fix JSFiddle

### DIFF
--- a/docs/0.4.0/Writing decorator plugins.md.hbs
+++ b/docs/0.4.0/Writing decorator plugins.md.hbs
@@ -4,7 +4,7 @@ title: Writing decorator plugins
 
 A {{{createLink 'decorators' 'decorator'}}} is a way to add behaviour to a node when it is rendered, or to augment it in some way.
 
-For this example we'll create a tooltip decorator. For the impatient, you can see the [finished result in this JSFiddle](http://jsfiddle.net/rich_harris/9g3pB/).
+For this example we'll create a tooltip decorator. For the impatient, you can see the [finished result in this JSFiddle](http://jsfiddle.net/tomByrer/9g3pB/11/).
 
 Firstly, we need to add the `decorator` *directive* to any nodes that the decorator should apply to:
 


### PR DESCRIPTION
"External Resources" had a bad rawgit.com URL.  Fixed to v0.4.0.
Sorry I didn't want to plaster my namespace over yours; but it will help if I need to re-edit, like if my suggestion for [shorter version URL is used](https://github.com/ractivejs/cdn.ractivejs.org/issues/1).  Feel free to re-fork to reclaim.
