### PR TITLE
Update ractive.render()

### DIFF
--- a/docs/0.5/ractive.render().md.hbs
+++ b/docs/0.5/ractive.render().md.hbs
@@ -2,4 +2,9 @@
 title: ractive.render()
 ---
 
-This method will throw an error if you call it! It exists so that components can override the standard render logic with their own (e.g. for delegating to external libraries, or rendering to a canvas - note that this is not well supported as of version 0.4.0).
+Renders the component into a DOM element.
+
+> ### ractive.render( target )
+
+> > #### **target** *`Node`* or *`String`* or *`jQuery`* (see {{{createLink 'Valid selectors'}}})
+> > The DOM element to render to


### PR DESCRIPTION
Updates render() with basic usage info.

The docs say that `render()` will throw an error, but it doesn't. In fact, calling `insert()` on a new component will ask you to invoke `render()`.

``` js
var r = new Ractive({ template: '<div>hi</div>' });
r.insert(document.body); // fail

var parent = document.createDocumentFragment(); /* or .createElement('DIV') */
r.render(parent);
r.insert(document.body); // ok
```
