### PR TITLE
Replace checkbox `value` attribute by `checked`

### DIFF
--- a/docs/0.5/References.md.hbs
+++ b/docs/0.5/References.md.hbs
@@ -116,7 +116,7 @@ Sometimes you may want to reference a property within the current context regard
 
 ```html
 \{{#options}}
-  <label><input type='checkbox' value='\{{.selected}}'> \{{description}}</label>
+  <label><input type='checkbox' checked='\{{.selected}}'> \{{description}}</label>
 \{{/options}}
 ```
 


### PR DESCRIPTION
The `value` attribute seems "not to work" for a checkbox, and `checked`
looks like the right way to bind a checkbox state.

This commit fixes the documentation to provide a working example.
