### PR TITLE
update readme and getting started link for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ grunt
 Running `grunt` will build the site and rebuild when docs changes. You need to use a local webserver to preview in your web browser. One easy option is to use [http-server](https://www.npmjs.org/package/http-server) (installable via `npm install -g http-server`). You need to run it from the `/build` directory and explicitly include `html` as the default extension (add `-s` for silent mode):
 
 ```sh
-docs.ractive.org/build>http-server -e html
+docs.ractive.org/build>python -m SimpleHTTPServer
 ```
 Open `localhost` on the port specified (usually `8080`), and it should redirect to `localhost:8080/latest/get-started`. Refresh to pick up changes made in docs.
 

--- a/root/index.html
+++ b/root/index.html
@@ -1,1 +1,1 @@
-<script>window.location.href='latest/get-started'</script>
+<script>window.location.href='latest/get-started.html'</script>


### PR DESCRIPTION
- [x] add simple python server for local doc viewing
- [x] add `.html` to `latest/get-started.html` so the default python server redirect correctly
