### PR TITLE
Changes example variable name to be consistent

### DIFF
--- a/docs/0.6/Components.md.hbs
+++ b/docs/0.6/Components.md.hbs
@@ -45,7 +45,7 @@ var ractive = new Ractive({
   el: 'body',
   template: '#template',
   data: {
-    nonIsolatedSetting: 'This is a non isolated setting, get it anywhere'
+    nonIsolatedString: 'This is a non isolated setting, get it anywhere'
   },
   components: { Component: Component }
 });


### PR DESCRIPTION
Fixes error in example for nonIsolatedString where data key was inconsistent between declaration and reference.