### PR TITLE
"binding" instead of "vinding"

### DIFF
--- a/docs/0.7/Two-way binding.md.hbs
+++ b/docs/0.7/Two-way binding.md.hbs
@@ -5,7 +5,7 @@ By default, a Ractive instance will update its internal model based on user inpu
 
 If that's unhelpful for your app, you can disable it by passing `twoway: false` as an {{{createLink 'options' 'initialisation option'}}}.
 
-Two-way vinding can also be overridden on a per-element basis using the `twoway` directive e.g. `<input value="\{{foo}}" twoway="false">`. If the `twoway` option is set to false, it can be overridden on a per-element bases using `twoway` as a boolean attribute e.g. `<input value="\{{foo}}" twoway>` or `<input value="\{{foo}}" twoway="true">`.
+Two-way binding can also be overridden on a per-element basis using the `twoway` directive e.g. `<input value="\{{foo}}" twoway="false">`. If the `twoway` option is set to false, it can be overridden on a per-element bases using `twoway` as a boolean attribute e.g. `<input value="\{{foo}}" twoway>` or `<input value="\{{foo}}" twoway="true">`.
 
 
 ## `<input>` elements


### PR DESCRIPTION
I think it should be "binding". One possible alternative could be "winding" but I'm not sure.
"two-way winding"?