### PR TITLE
update deprecated partial syntax

### DIFF
--- a/docs/0.7/Partials.md.hbs
+++ b/docs/0.7/Partials.md.hbs
@@ -146,13 +146,13 @@ If a partial expression is a simple reference and a partial exists with the same
 ```html
 \{{#list}}\{{>.type}}\{{/}}
 
-<!-- \{{>person}} -->
+\{{#partial person}}
   \{{.name}} is a person. \{{.pronoun}} has \{{.fingerCount}} fingers.
-<!-- \{{/person}} -->
+\{{/partial person}}
 
-<!-- \{{>animal}} -->
+\{{#partial animal}}
   \{{.name}} is a \{{.specie}}. \{{.pronoun}} has \{{.legCount}} legs.
-<!-- \{{/animal}} -->
+\{{/partial animal}}
 ```
 
 This example uses a combination of patial expressions and restricted references in the iteration of `list` to render a different template based on the `type` of item in the list. If there was an item `{ type: 'person', name: 'John', pronoun: 'He', fingerCount: 9 }` in the list, its output would be `John is a person. He has 9 fingers.`. `{ type: 'animal', name: 'Alfred', specie: 'starfish', pronoun: 'It', legCount: 5 }` would output `Alfred is a starfish. It has 5 legs.`.


### PR DESCRIPTION
Sorry I couldn't run the build. `npm install` was giving me this error: 

`Failed at the node-sass@0.8.6 install script 'node build.js'.`

So here's the source updates, fwiw.