### PR TITLE
Include new "SlideHorizontal" plugin

### DIFF
--- a/docs/0.7/Plugins.md.hbs
+++ b/docs/0.7/Plugins.md.hbs
@@ -49,6 +49,7 @@ plugin API pages under "Writing" and the [plugin template](https://github.com/Ra
 * [Fly](http://ractivejs.github.io/ractive-transitions-fly)
 * [Scale](https://github.com/1N50MN14/Ractive-transitions-scale) - contributed by [@1N50MN14](https://github.com/1N50MN14)
 * [Slide](http://ractivejs.github.io/ractive-transitions-slide)
+* [SlideHorizontal](https://github.com/zenflow/ractive-transitions-slidehorizontal) - contributed by [@zenflow](https://github.com/zenflow)
 * [Typewriter](http://ractivejs.github.io/ractive-transitions-typewriter)
 
 ## {{{createLink 'Components'}}}


### PR DESCRIPTION
Please include this plugin on the ractive docs plugins page, so others can find and use it. 
Created with the Ractive.js plugin template for Grunt.
Check out the [demo page](http://zenflow.github.io/ractive-transitions-slidehorizontal/)
Thanks!