### PR TITLE
Fix link on ractive.update() page

### DIFF
--- a/docs/0.7/ractive.update().md.hbs
+++ b/docs/0.7/ractive.update().md.hbs
@@ -2,7 +2,7 @@
 title: ractive.update()
 ---
 
-Forces everything that depends on the specified {{{createLink 'keypath' 'keypaths'}}} (whether directly or indirectly) to be 'dirty checked'. This is useful if you manipulate data without using the built in setter methods (i.e. {{{createLink 'ractive.set()'}}}, {{{createLink 'ractive.animate()'}}}, or {{{createLink 'array modification' 'array modification'}}}):
+Forces everything that depends on the specified {{{createLink 'keypaths'}}} (whether directly or indirectly) to be 'dirty checked'. This is useful if you manipulate data without using the built in setter methods (i.e. {{{createLink 'ractive.set()'}}}, {{{createLink 'ractive.animate()'}}}, or {{{createLink 'array modification' 'array modification'}}}):
 
 ```js
 ractive.observe( 'foo', function ( foo ) {


### PR DESCRIPTION
Update link to point to 'keypaths' instead of 'keypath'