### PR TITLE
`noCSSTransform` to `noCssTransform`

### DIFF
--- a/docs/0.7/Options.md.hbs
+++ b/docs/0.7/Options.md.hbs
@@ -135,7 +135,7 @@ ractive.myMethod(); // triggers the alert
 > Used on components to specify `css` styles to be inserted into the document.
 
 > <a id="noCssTransform"></a>
-> ### noCSSTransform *`Boolean`*
+> ### noCssTransform *`Boolean`*
 > Defaults to `false`. Prevents component css from being transformed with scoping guids.
 
 


### PR DESCRIPTION
The property's header was improperly cased and did not match the implementation.