### PR TITLE
Add ractive-tooltip, ractive-datatable to list of Plugins

### DIFF
--- a/docs/0.7/Plugins.md.hbs
+++ b/docs/0.7/Plugins.md.hbs
@@ -18,6 +18,13 @@ plugin API pages under "Writing" and the [plugin template](https://github.com/Ra
 * [Stapes](https://github.com/dwightjack/ractive-adaptors-stapes) - contributed by [@dwightjack](https://github.com/dwightjack)
 * TODO: Object.observe
 
+## {{{createLink 'Components'}}}
+
+* [Ractive-Require](https://github.com/XavierBoubert/ractive-require)
+* [CodeMirror](http://dagnelies.github.io/ractive-codemirror/)
+* [Bootstrap](http://dagnelies.github.io/ractive-bootstrap/)
+* [Datatable](https://github.com/JonDum/ractive-datatable)
+
 
 ## {{{createLink 'Decorators'}}}
 
@@ -25,6 +32,7 @@ plugin API pages under "Writing" and the [plugin template](https://github.com/Ra
 * [minmaxwidth](https://github.com/cfenzo/Ractive-decorators-minmaxwidth) - contributed by [@cfenzo](https://github.com/cfenzo)
 * [Select2](http://prezent.github.io/ractive-decorators-select2/) - contributed by [@sandermarechal](https://github.com/sandermarechal) ([@Prezent](https://github.com/Prezent))
 * [Sortable](http://ractivejs.github.io/Ractive-decorators-sortable/)
+* [Tooltip](http://github.com/JonDum/ractive-tooltip)
 
 
 ## {{{createLink 'Events'}}}
@@ -52,8 +60,3 @@ plugin API pages under "Writing" and the [plugin template](https://github.com/Ra
 * [SlideHorizontal](https://github.com/zenflow/ractive-transitions-slidehorizontal) - contributed by [@zenflow](https://github.com/zenflow)
 * [Typewriter](http://ractivejs.github.io/ractive-transitions-typewriter)
 
-## {{{createLink 'Components'}}}
-
-* [Ractive-Require](https://github.com/XavierBoubert/ractive-require)
-* [CodeMirror](http://dagnelies.github.io/ractive-codemirror/)
-* [Bootstrap](http://dagnelies.github.io/ractive-bootstrap/)

--- a/docs/0.7/Writing decorator plugins.md.hbs
+++ b/docs/0.7/Writing decorator plugins.md.hbs
@@ -172,6 +172,18 @@ Ractive.decorators.tooltip = tooltipDecorator;
 Ractive.decorators.tooltip.className = 'tooltips-ftw';
 ```
 
+You can use a tooltip like this in your app with the [ractive-tooltip](http://github.com/JonDum/ractive-tooltip) package available on NPM.
+Install it via `npm install ractive-tooltip --save` and use it in your app with
+```js
+ractive = new Ractive({
+    ...
+    decorators: {
+        tooltip: require('ractive-tooltip')
+    },
+    ...
+});
+```
+
 
 ## Sharing your decorators
 

--- a/docs/edge/Plugins.md.hbs
+++ b/docs/edge/Plugins.md.hbs
@@ -17,6 +17,12 @@ plugin API pages under "Writing" and the [plugin template](https://github.com/Ra
 * [ss-ractive](https://github.com/arxpoetica/ss-ractive) (Ractive Template Engine wrapper for [SocketStream](https://github.com/socketstream/socketstream)) - by Robert Hall [@arxpoetica](https://github.com/arxpoetica)
 * TODO: Object.observe
 
+## {{{createLink 'Components'}}}
+
+* [Ractive-Require](https://github.com/XavierBoubert/ractive-require)
+* [CodeMirror](http://dagnelies.github.io/ractive-codemirror/)
+* [Bootstrap](http://dagnelies.github.io/ractive-bootstrap/)
+* [Datatable](https://github.com/JonDum/ractive-datatable)
 
 ## {{{createLink 'Decorators'}}}
 
@@ -24,6 +30,7 @@ plugin API pages under "Writing" and the [plugin template](https://github.com/Ra
 * [minmaxwidth](https://github.com/cfenzo/Ractive-decorators-minmaxwidth) - contributed by [@cfenzo](https://github.com/cfenzo)
 * [Select2](http://prezent.github.io/ractive-decorators-select2/) - contributed by [@sandermarechal](https://github.com/sandermarechal) ([@Prezent](https://github.com/Prezent))
 * [Sortable](http://ractivejs.github.io/Ractive-decorators-sortable/)
+* [Tooltip](http://github.com/JonDum/ractive-tooltip)
 
 
 ## {{{createLink 'Events'}}}
@@ -41,7 +48,6 @@ plugin API pages under "Writing" and the [plugin template](https://github.com/Ra
 * [Viewport](https://github.com/svapreddy/ractive-event-viewport) - contributed by [@svapreddy](https://github.com/svapreddy)
 
 
-
 ## {{{createLink 'Transitions'}}}
 
 * [Fade](http://ractivejs.github.io/ractive-transitions-fade)
@@ -49,3 +55,5 @@ plugin API pages under "Writing" and the [plugin template](https://github.com/Ra
 * [Scale](https://github.com/1N50MN14/Ractive-transitions-scale) - contributed by [@1N50MN14](https://github.com/1N50MN14)
 * [Slide](http://ractivejs.github.io/ractive-transitions-slide)
 * [Typewriter](http://ractivejs.github.io/ractive-transitions-typewriter)
+
+

--- a/docs/edge/Writing decorator plugins.md.hbs
+++ b/docs/edge/Writing decorator plugins.md.hbs
@@ -172,6 +172,18 @@ Ractive.decorators.tooltip = tooltipDecorator;
 Ractive.decorators.tooltip.className = 'tooltips-ftw';
 ```
 
+You can use a tooltip like this in your app with the [ractive-tooltip](http://github.com/JonDum/ractive-tooltip) package available on NPM.
+Install it via `npm install ractive-tooltip --save` and use it in your app with
+```js
+ractive = new Ractive({
+    ...
+    decorators: {
+        tooltip: require('ractive-tooltip')
+    },
+    ...
+});
+```
+
 
 ## Sharing your decorators
 


### PR DESCRIPTION
Hey guys, I got tired of having copies of my tooltip decorator all over the place so I put it up on npm under [ractive-tooltip](https://github.com/JonDum/ractive-tooltip). It's basically the version from the docs with some extra logic to make sure the tooltip doesn't get clipped by the edge of the screen. It'll also be nice to standardize on some frequently used components/decorators for PRs and stuff instead of everyone writing and maintaining their own. 

I also added my other component [ractive-datatable](https://github.com/JonDum/ractive-datatable) while I was at it.