### PR TITLE
update the Ractive-Require new link

### DIFF
--- a/docs/0.7/Plugins.md.hbs
+++ b/docs/0.7/Plugins.md.hbs
@@ -20,7 +20,7 @@ plugin API pages under "Writing" and the [plugin template](https://github.com/Ra
 
 ## {{{createLink 'Components'}}}
 
-* [Ractive-Require](https://github.com/XavierBoubert/ractive-require)
+* [Ractive-Require](http://ractive-require.codecorico.com) contributed by the [CodeCorico team](https://github.com/codecorico)
 * [CodeMirror](http://dagnelies.github.io/ractive-codemirror/)
 * [Bootstrap](http://dagnelies.github.io/ractive-bootstrap/)
 * [Datatable](https://github.com/JonDum/ractive-datatable)


### PR DESCRIPTION
Now the project is supported by the open CodeCorico team to be more public.
A new documentation website is available.