### PR TITLE
Updated unsupported plugins w/ functional ones

### DIFF
--- a/0.7/plugins.html
+++ b/0.7/plugins.html
@@ -81,9 +81,7 @@ plugin API pages under &quot;Writing&quot; and the <a href="https://github.com/R
 </ul>
 <h2 id="-a-href-events-events-a-"><a href="events">Events</a></h2>
 <ul>
-<li><a href="https://github.com/Nijikokun/ractive.drag.drop.js">Drag and Drop (HTML5)</a> - contributed by <a href="https://github.com/Nijikokun">@Nijikokun</a></li>
 <li><a href="https://github.com/smallhadroncollider/ractive.events.drag">Drag and Drop (non-HTML5)</a> - contributed by <a href="https://github.com/smallhadroncollider">@smallhadroncollider</a></li>
-<li><a href="https://github.com/Nijikokun/ractive.sortable.js">Drag and Drop Sortable List</a> - contributed by <a href="https://github.com/Nijikokun">@Nijikokun</a></li>
 <li><a href="https://github.com/smallhadroncollider/ractive.events.resize">Resize</a> - contributed by <a href="https://github.com/smallhadroncollider">@smallhadroncollider</a></li>
 <li><a href="http://ractivejs.github.io/ractive-events-hover">Hover</a></li>
 <li><a href="http://ractivejs.github.io/ractive-events-keys">Keys</a></li>
@@ -91,7 +89,9 @@ plugin API pages under &quot;Writing&quot; and the <a href="https://github.com/R
 <li><a href="http://ractivejs.github.io/ractive-events-tap">Tap</a></li>
 <li><a href="https://github.com/rstacruz/ractive-touch">Touch</a> - contributed by <a href="https://github.com/rstacruz/">@rstacruz</a></li>
 <li><a href="https://github.com/svapreddy/ractive-events-typing">Typing</a> - contributed by <a href="https://github.com/svapreddy">@svapreddy</a></li>
-<li><a href="https://github.com/svapreddy/ractive-event-viewport">Viewport</a> - contributed by <a href="https://github.com/svapreddy">@svapreddy</a></li>
+<li><a href="https://github.com/svapreddy/ractive-event-viewport">Viewport</a> - contributed by <a href="https://github.com/svapreddy">@svapreddy</a></li> 
+<li><a href="https://github.com/webraptor/ractive.dragging.js">Dragging (HTML5)</a> - contributed by <a href="https://github.com/webraptor">@webRaptor</a></li>
+<li><a href="https://github.com/webraptor/ractive.sortable.js">Sortable (HTML5)</a> - contributed by <a href="https://github.com/webraptor">@webRaptor</a></li>
 </ul>
 <h2 id="-a-href-transitions-transitions-a-"><a href="transitions">Transitions</a></h2>
 <ul>

--- a/edge/plugins.html
+++ b/edge/plugins.html
@@ -79,9 +79,7 @@ plugin API pages under &quot;Writing&quot; and the <a href="https://github.com/R
 </ul>
 <h2 id="-a-href-events-events-a-"><a href="events">Events</a></h2>
 <ul>
-<li><a href="https://github.com/Nijikokun/ractive.drag.drop.js">Drag and Drop (HTML5)</a> - contributed by <a href="https://github.com/Nijikokun">@Nijikokun</a></li>
 <li><a href="https://github.com/smallhadroncollider/ractive.events.drag">Drag and Drop (non-HTML5)</a> - contributed by <a href="https://github.com/smallhadroncollider">@smallhadroncollider</a></li>
-<li><a href="https://github.com/Nijikokun/ractive.sortable.js">Drag and Drop Sortable List</a> - contributed by <a href="https://github.com/Nijikokun">@Nijikokun</a></li>
 <li><a href="https://github.com/smallhadroncollider/ractive.events.resize">Resize</a> - contributed by <a href="https://github.com/smallhadroncollider">@smallhadroncollider</a></li>
 <li><a href="http://ractivejs.github.io/ractive-events-hover">Hover</a></li>
 <li><a href="http://ractivejs.github.io/ractive-events-keys">Keys</a></li>
@@ -89,7 +87,9 @@ plugin API pages under &quot;Writing&quot; and the <a href="https://github.com/R
 <li><a href="http://ractivejs.github.io/ractive-events-tap">Tap</a></li>
 <li><a href="https://github.com/rstacruz/ractive-touch">Touch</a> - contributed by <a href="https://github.com/rstacruz/">@rstacruz</a></li>
 <li><a href="https://github.com/svapreddy/ractive-events-typing">Typing</a> - contributed by <a href="https://github.com/svapreddy">@svapreddy</a></li>
-<li><a href="https://github.com/svapreddy/ractive-event-viewport">Viewport</a> - contributed by <a href="https://github.com/svapreddy">@svapreddy</a></li>
+<li><a href="https://github.com/svapreddy/ractive-event-viewport">Viewport</a> - contributed by <a href="https://github.com/svapreddy">@svapreddy</a></li>  
+<li><a href="https://github.com/webraptor/ractive.dragging.js">Dragging (HTML5)</a> - contributed by <a href="https://github.com/webraptor">@webRaptor</a></li>
+<li><a href="https://github.com/webraptor/ractive.sortable.js">Sortable (HTML5)</a> - contributed by <a href="https://github.com/webraptor">@webRaptor</a></li>
 </ul>
 <h2 id="-a-href-transitions-transitions-a-"><a href="transitions">Transitions</a></h2>
 <ul>

--- a/latest/plugins.html
+++ b/latest/plugins.html
@@ -81,9 +81,7 @@ plugin API pages under &quot;Writing&quot; and the <a href="https://github.com/R
 </ul>
 <h2 id="-a-href-events-events-a-"><a href="events">Events</a></h2>
 <ul>
-<li><a href="https://github.com/Nijikokun/ractive.drag.drop.js">Drag and Drop (HTML5)</a> - contributed by <a href="https://github.com/Nijikokun">@Nijikokun</a></li>
 <li><a href="https://github.com/smallhadroncollider/ractive.events.drag">Drag and Drop (non-HTML5)</a> - contributed by <a href="https://github.com/smallhadroncollider">@smallhadroncollider</a></li>
-<li><a href="https://github.com/Nijikokun/ractive.sortable.js">Drag and Drop Sortable List</a> - contributed by <a href="https://github.com/Nijikokun">@Nijikokun</a></li>
 <li><a href="https://github.com/smallhadroncollider/ractive.events.resize">Resize</a> - contributed by <a href="https://github.com/smallhadroncollider">@smallhadroncollider</a></li>
 <li><a href="http://ractivejs.github.io/ractive-events-hover">Hover</a></li>
 <li><a href="http://ractivejs.github.io/ractive-events-keys">Keys</a></li>
@@ -91,7 +89,9 @@ plugin API pages under &quot;Writing&quot; and the <a href="https://github.com/R
 <li><a href="http://ractivejs.github.io/ractive-events-tap">Tap</a></li>
 <li><a href="https://github.com/rstacruz/ractive-touch">Touch</a> - contributed by <a href="https://github.com/rstacruz/">@rstacruz</a></li>
 <li><a href="https://github.com/svapreddy/ractive-events-typing">Typing</a> - contributed by <a href="https://github.com/svapreddy">@svapreddy</a></li>
-<li><a href="https://github.com/svapreddy/ractive-event-viewport">Viewport</a> - contributed by <a href="https://github.com/svapreddy">@svapreddy</a></li>
+<li><a href="https://github.com/svapreddy/ractive-event-viewport">Viewport</a> - contributed by <a href="https://github.com/svapreddy">@svapreddy</a></li>   
+<li><a href="https://github.com/webraptor/ractive.dragging.js">Dragging (HTML5)</a> - contributed by <a href="https://github.com/webraptor">@webRaptor</a></li>
+<li><a href="https://github.com/webraptor/ractive.sortable.js">Sortable (HTML5)</a> - contributed by <a href="https://github.com/webraptor">@webRaptor</a></li>
 </ul>
 <h2 id="-a-href-transitions-transitions-a-"><a href="transitions">Transitions</a></h2>
 <ul>


### PR DESCRIPTION
Old Drag & Drop and Sortable plugins no longer work with ractive latest versions.

Added 2 new plugins (one of which is a fork of the original that isn't maintained anymore) that work with latest ractive versions, including 0.8.0 edge.