### PR TITLE
Round 2 of 0.8 updates

### DIFF
--- a/docs/edge/Elements.md.hbs
+++ b/docs/edge/Elements.md.hbs
@@ -1,0 +1,38 @@
+---
+title: Elements
+---
+
+Just about any useful template will contain at least one HTML element, and Ractive has a few directiives and other constructs built into its element representation to make life easier. Some of these constructs have their own sections in the docs, such as {{{ createLink 'Events overview' 'Events' }}}, {{{ createLink 'Transitions' }}}, {{{ createLink 'Two-way binding' 'Bindings' }}}, {{{ createLink 'Decoratros' }}}, and {{{ createLink 'Components' }}}.
+
+## Conditional attributes
+
+You can wrap one or more attributes inside an element tag in a conditional section, and Ractive will add and remove those attributes as the conditional section is rendered and unrendered. For instance:
+
+```html
+<ul>
+\{{#each list as item}}
+	<li \{{#if ~/selectedItems.indexOf(item) !== -1}}class="selected"\{{/if}}>
+		\{{item.name}}
+	</li>
+\{{/each}}
+</ul>
+```
+
+In this example, if the current `item` in the `list` iteration is also in the `selectedItems` array, then a class attribute will be added to the rendered li and set to `"selected"`.
+
+Any number of attributes can be used in a section, and other {{{ createLink 'Mustaches' 'Mustache' }}} constructs can be used to supply attributes.
+
+## Class and style attributes
+
+Ractive has special handlers for style and class attributes that only add and remove values for classes or style properties that are in the template. This allows external code to modify the element without Ractive overriding the change on its next update.
+
+There are also two special classes of attributes for handling a single class or style property at a time.
+
+### `style-*` attributes
+
+To facilitate quick updates to a single style property of an element, Ractive supports using `style-property-name="value"` or `style-propertyName="value"` attributes. The value may be any text including any mustaches, and when the value is updated, the appropriate style property on the element will be updated with the new value. Any hyphens after the first will be removed and the subsequent letter capitalized so both `style-text-align` and `style-textAlign` will target the `textAlign` property of the element's style.
+
+### `class-*` attributes
+
+To facilitate easily adding and removing a single class on an element, Ractive supports using `class-class-name` and `class-className` attributes. Unlike style attributes, no changes are made to the hyphenation of the attribute name, so `class-class-name` and class-className` will target `class-name` and `className`, respectively. The truthiness of the value assigned to a `class-` attribute determines whether or not Ractive will add the class to the element. If the value is truthy, the class will be added. If the value becomes falsey, then the class will be removed. No other classes on the element will be affected by changes to a `class-` attribute.
+

--- a/docs/edge/Elements.md.hbs
+++ b/docs/edge/Elements.md.hbs
@@ -2,7 +2,7 @@
 title: Elements
 ---
 
-Just about any useful template will contain at least one HTML element, and Ractive has a few directiives and other constructs built into its element representation to make life easier. Some of these constructs have their own sections in the docs, such as {{{ createLink 'Events overview' 'Events' }}}, {{{ createLink 'Transitions' }}}, {{{ createLink 'Two-way binding' 'Bindings' }}}, {{{ createLink 'Decoratros' }}}, and {{{ createLink 'Components' }}}.
+Just about any useful template will contain at least one HTML element, and Ractive has a few directives and other constructs built into its element representation to make life easier. Some of these constructs have their own sections in the docs, such as {{{ createLink 'Events overview' 'Events' }}}, {{{ createLink 'Transitions' }}}, {{{ createLink 'Two-way binding' 'Bindings' }}}, {{{ createLink 'Decoratros' }}}, and {{{ createLink 'Components' }}}.
 
 ## Conditional attributes
 

--- a/docs/edge/Migrating.md.hbs
+++ b/docs/edge/Migrating.md.hbs
@@ -42,7 +42,7 @@ You can now retrieve the CSS for a Ractive instance with a new `toCSS` method. Y
 
 You can now trigger a transition with `ractive.transition( transition, node, options )`, and `node` can be supplied implicitly from an event handler. Transitions can now return a Promise and `complete` will automatically be called when the promise resolves.
 
-Class and style attributes now get special treatment that keeps them from clobbering external changes. There are also special attribute forms for targeting a single class or inline style at a time using e.g. `style-left="\{{x}}px"` and `class-someClass="\{{someCondition || someOtherCondition}}"`. For the special style form, additional hyphens in the attribute are turned into caeml case. For the special class form, the truthiness of the value determines whether or not the class is added to the list.
+Class and style attributes now get special treatment that keeps them from clobbering external changes. There are also special attribute forms for targeting a single class or inline style at a time using e.g. `style-left="\{{x}}px"` and `class-someClass="\{{someCondition || someOtherCondition}}"`. For the special style form, additional hyphens in the attribute are turned into camel case. For the special class form, the truthiness of the value determines whether or not the class is added to the list.
 
 As `set` will create intermediate objects when setting an undefined keypath, array methods will now swap in an empty array instead of erroring when called with an undefined keypath. Trying to use an array method with a non-array value including `null` will still throw.
 

--- a/docs/edge/Migrating.md.hbs
+++ b/docs/edge/Migrating.md.hbs
@@ -40,6 +40,12 @@ Partials defined in `<script>` tags can now contain top-level inline partial def
 
 You can now retrieve the CSS for a Ractive instance with a new `toCSS` method. You can also get the CSS for all instances with a new static Ractive method of the same name.
 
+You can now trigger a transition with `ractive.transition( transition, node, options )`, and `node` can be supplied implicitly from an event handler. Transitions can now return a Promise and `complete` will automatically be called when the promise resolves.
+
+Class and style attributes now get special treatment that keeps them from clobbering external changes. There are also special attribute forms for targeting a single class or inline style at a time using e.g. `style-left="{{x}}px"` and `class-someClass="{{someCondition || someOtherCondition}}"`. For the special style form, additional hyphens in the attribute are turned into caeml case. For the special class form, the truthiness of the value determines whether or not the class is added to the list.
+
+As `set` will create intermediate objects when setting an undefined keypath, array methods will now swap in an empty array instead of erroring when called with an undefined keypath. Trying to use an array method with a non-array value including `null` will still throw.
+
 ### Breaking changes and deprecation
 
 * Names in partial mustaches have been further relaxed to allow `/`s. They can also now handle relative contexts because partial name expressions no longer support spaces around the `.` delimiters in object paths. `\{{> foo.bar.baz .bat}}` before this change would have parsed as a single expression to get the partial name from `foo.bar.baz.bat`. It will now get the name from `foo.bar.baz` and have a context provided from `.bat`.
@@ -50,7 +56,7 @@ You can now retrieve the CSS for a Ractive instance with a new `toCSS` method. Y
 
 * The private `_ractive` tracking data added to Ractive controlled DOM nodes has changed significantly. The format of `Ractive.getNodeInfo` objects is still compatible.
 
-* `\{{#with obj}}` to not render if `obj` is falsey (https://github.com/ractivejs/ractive/issues/1856)
+* `\{{#with obj}}` will no longer render if `obj` is falsey (https://github.com/ractivejs/ractive/issues/1856)
 
 ## Migrating from 0.6.x
 

--- a/docs/edge/Migrating.md.hbs
+++ b/docs/edge/Migrating.md.hbs
@@ -42,7 +42,7 @@ You can now retrieve the CSS for a Ractive instance with a new `toCSS` method. Y
 
 You can now trigger a transition with `ractive.transition( transition, node, options )`, and `node` can be supplied implicitly from an event handler. Transitions can now return a Promise and `complete` will automatically be called when the promise resolves.
 
-Class and style attributes now get special treatment that keeps them from clobbering external changes. There are also special attribute forms for targeting a single class or inline style at a time using e.g. `style-left="{{x}}px"` and `class-someClass="{{someCondition || someOtherCondition}}"`. For the special style form, additional hyphens in the attribute are turned into caeml case. For the special class form, the truthiness of the value determines whether or not the class is added to the list.
+Class and style attributes now get special treatment that keeps them from clobbering external changes. There are also special attribute forms for targeting a single class or inline style at a time using e.g. `style-left="\{{x}}px"` and `class-someClass="\{{someCondition || someOtherCondition}}"`. For the special style form, additional hyphens in the attribute are turned into caeml case. For the special class form, the truthiness of the value determines whether or not the class is added to the list.
 
 As `set` will create intermediate objects when setting an undefined keypath, array methods will now swap in an empty array instead of erroring when called with an undefined keypath. Trying to use an array method with a non-array value including `null` will still throw.
 

--- a/docs/edge/ractive.pop().md.hbs
+++ b/docs/edge/ractive.pop().md.hbs
@@ -9,4 +9,4 @@ The Ractive equivalent to ```Array.pop``` that removes an element from the end o
 > > #### **keypath** *`String`*
 > > The {{{createLink 'keypaths' 'keypath'}}} of the array to change, e.g. `list` or `order.items`.
 
-If the given keypath does not resolve to an array, an error will be thrown.
+If the given keypath does not exist (is `undefined`), an empty array will be supplied instead. Otherwise, if the given keypath does not resolve to an array, an error will be thrown.

--- a/docs/edge/ractive.push().md.hbs
+++ b/docs/edge/ractive.push().md.hbs
@@ -12,4 +12,4 @@ The Ractive equivalent to ```Array.push``` that appends one or more elements to 
 > > #### **value**
 > > The value to append to the end of the array. One or more values may be supplied.
 
-If the given keypath does not resolve to an array, an error will be thrown.
+If the given keypath does not exist (is `undefined`), an empty array will be supplied instead. Otherwise, if the given keypath does not resolve to an array, an error will be thrown.

--- a/docs/edge/ractive.shift().md.hbs
+++ b/docs/edge/ractive.shift().md.hbs
@@ -9,4 +9,4 @@ The Ractive equivalent to ```Array.shift``` that removes an element from the beg
 > > #### **keypath** *`String`*
 > > The {{{createLink 'keypaths' 'keypath'}}} of the array to change, e.g. `list` or `order.items`.
 
-If the given keypath does not resolve to an array, an error will be thrown.
+If the given keypath does not exist (is `undefined`), an empty array will be supplied instead. Otherwise, if the given keypath does not resolve to an array, an error will be thrown.

--- a/docs/edge/ractive.splice().md.hbs
+++ b/docs/edge/ractive.splice().md.hbs
@@ -18,4 +18,4 @@ The Ractive equivalent to ```Array.splice``` that can add new elements to the ar
 > > #### **add**
 > > Any elements to insert into the array starting at *`index`*. There can be 0 or more elements passed to add to the array.
 
-If the given keypath does not resolve to an array, an error will be thrown.
+If the given keypath does not exist (is `undefined`), an empty array will be supplied instead. Otherwise, if the given keypath does not resolve to an array, an error will be thrown.

--- a/docs/edge/ractive.transition().md.hbs
+++ b/docs/edge/ractive.transition().md.hbs
@@ -1,0 +1,12 @@
+---
+title: ractive.transition()
+---
+Triggers a transition on a node managed by this Ractive instance.
+
+> ### ractive.transition( transition, node, options )
+> > #### **transition*** *`String`* or *`Function`*
+> > The name of the transition or a transition function
+> > #### **node** *`HTMLElement`*
+> > The node on which to start the transition - optional if called from within a Ractive event handler, as it will be retrieved from the event if not supplied.
+> > #### **options** *`Object`*
+> > Options supplied to the transition

--- a/docs/edge/ractive.unshift().md.hbs
+++ b/docs/edge/ractive.unshift().md.hbs
@@ -12,4 +12,4 @@ The Ractive equivalent to ```Array.unshift``` that prepends one or more elements
 > > #### **value**
 > > The value to prepend to the beginning of the array. One or more values may be supplied.
 
-If the given keypath does not resolve to an array, an error will be thrown.
+If the given keypath does not exist (is `undefined`), an empty array will be supplied instead. Otherwise, if the given keypath does not resolve to an array, an error will be thrown.

--- a/scss/_dimensions.scss
+++ b/scss/_dimensions.scss
@@ -1,3 +1,3 @@
 $leftNavWidth: 16em;
-$leftNavHeight: 240em;
+$leftNavHeight: 260em;
 $fullWidth: 48em;

--- a/templates/edge/partials/left-nav.md.hbs
+++ b/templates/edge/partials/left-nav.md.hbs
@@ -102,6 +102,7 @@
 		<li>{{{createLink 'ractive.teardown()'}}}</li>
 		<li>{{{createLink 'ractive.toggle()'}}}</li>
 		<li>{{{createLink 'ractive.toHTML()'}}}</li>
+		<li>{{{createLink 'ractive.transition()'}}}</li>
 		<li>{{{createLink 'ractive.unlink()'}}}</li>
 		<li>{{{createLink 'ractive.unrender()'}}}</li>
 		<li>{{{createLink 'ractive.unshift()'}}}</li>

--- a/templates/edge/partials/left-nav.md.hbs
+++ b/templates/edge/partials/left-nav.md.hbs
@@ -24,6 +24,7 @@
 	<h2>Templates</h2>
 	<ul>
 		<li>{{{createLink 'Templates'}}}</li>
+		<li>{{{createLink 'Elements'}}}</li>
 		<li>{{{createLink 'Mustaches'}}}</li>
 		<li>{{{createLink 'References'}}}</li>
 		<li>{{{createLink 'Expressions'}}}</li>


### PR DESCRIPTION
Notably:

* add a few more changes to the migration list
* add a page for the new `transition` method
* update the array methods pages for the new branching behavior
* add an elements page under templates that documents conditional attributes and new class and style handling