### PR TITLE
Live example for minimum component declaration 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,7 +45,7 @@ module.exports = function ( grunt ) {
 
 		getEditLink: function ( file ) {
 			var source = grunt.editLinkReverseMapping[ file ];
-			return 'https://github.com/ractivejs/docs.ractivejs.org/edit/master/docs/' + source;
+			return 'https://github.com/ractivejs/v0.x/edit/master/docs/' + source;
 		}
 	};
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-docs.ractivejs.org
+v0.x
 ==================
 
-The documentation for [Ractive.js](http://ractivejs.org).
+The documentation for [Ractive.js](http://ractive.js.org).
 
 
 Building
@@ -9,8 +9,8 @@ Building
 
 ```
 # clone the repo
-$ git clone https://github.com/RactiveJS/docs.ractivejs.org.git
-$ cd docs.ractivejs.org
+$ git clone https://github.com/RactiveJS/v0.x.git
+$ cd v0.x
 
 # install dev dependencies (grunt and friends)
 $ npm install
@@ -29,7 +29,7 @@ Open `localhost` on the port specified (usually `8080`), and it should redirect 
 Contributing
 ------------
 
-If you see something wrong, out of date, or missing from this documentation, please [raise an issue on GitHub](https://github.com/RactiveJS/docs.ractivejs.org/issues) or - even better - submit a pull request. Your fellow Ractive users will thank you!
+If you see something wrong, out of date, or missing from this documentation, please [raise an issue on GitHub](https://github.com/RactiveJS/v0.x/issues) or - even better - submit a pull request. Your fellow Ractive users will thank you!
 
 In lieu of formal contribution guidelines, take care to follow the existing structure and conventions. Send pull requests to the `master` branch, not `gh-pages` (which is a snapshot of the `build` folder in `master`).
 

--- a/docs/0.3.9/60-second setup.md.hbs
+++ b/docs/0.3.9/60-second setup.md.hbs
@@ -88,4 +88,4 @@ That's it - you're in business.
 
 * You could pass in a template string as the `template` option, rather than the ID of a script tag containing the template. In that case, if your template is more than a couple of lines you'll probably want to keep it in a separate file and load it (e.g. with `$.ajax`, if you're using jQuery)
 * As your app grows in complexity, you'll want to keep your application code (i.e. the bit that calls `new Ractive()`) in a separate file. You can also [use Ractive with RequireJS](using-ractive-with-requirejs).
-* Work your way through the [tutorials](http://learn.ractivejs.org) to learn how to use Ractive. You can also consult the {{{createLink 'API reference'}}}.
+* Work your way through the [tutorials](http://learn.ractive.js.org) to learn how to use Ractive. You can also consult the {{{createLink 'API reference'}}}.

--- a/docs/0.3.9/Adaptors.md.hbs
+++ b/docs/0.3.9/Adaptors.md.hbs
@@ -4,7 +4,7 @@ title: Adaptors
 
 Adaptors are a way of teaching Ractive to communicate seamlessly with other libraries such as Backbone. This means that you can, for example, have some or all of your app's data handled by Backbone - including fetching from and saving to your server, validation, sorting, filtering and so on - but still build a reactive user interface using Ractive, without having to create custom View classes or adding a whole load of event binding code.
 
-It's probably easier to show, rather than tell: [this example application](http://ractivejs.org/examples/backbone) uses Backbone models describing all the James Bond films. The [code for the Backbone adaptor is here](https://github.com/RactiveJS/plugins.adaptors.Backbone).
+It's probably easier to show, rather than tell: [this example application](http://ractive.js.org/examples/backbone) uses Backbone models describing all the James Bond films. The [code for the Backbone adaptor is here](https://github.com/RactiveJS/plugins.adaptors.Backbone).
 
 
 Using adaptors

--- a/docs/0.3.9/Contributing.md.hbs
+++ b/docs/0.3.9/Contributing.md.hbs
@@ -10,7 +10,7 @@ Pull requests are always welcome on [GitHub](https://github.com/ractivejs/ractiv
 ## Other ways to contribute
 
 * Spread the word! The larger the community using Ractive, the better it becomes. Write blog posts, mention it to your developer colleagues and friends, submit talks (here are some [tips on speaking at tech meetups](http://speaking.io/)).
-* Fix documentation. Each page on this site has an 'edit' button in the top right, which will take you to GitHub where you can submit fixes. If you spot an error or think something's missing and aren't sure how to fix it, [raise an issue](https://github.com/ractivejs/docs.ractivejs.org/issues).
+* Fix documentation. Each page on this site has an 'edit' button in the top right, which will take you to GitHub where you can submit fixes. If you spot an error or think something's missing and aren't sure how to fix it, [raise an issue](https://github.com/ractivejs/v0.x/issues).
 * Help other developers on StackOverflow. Subscribe to [questions tagged 'ractivejs'](http://stackoverflow.com/questions/tagged/ractivejs), and you'll get alerts when someone asks a question that you might be able to answer.
 * Write plugins. See the {{{createLink 'Create plugins'}}} page for more information.
 

--- a/docs/0.3.9/Decorators.md.hbs
+++ b/docs/0.3.9/Decorators.md.hbs
@@ -68,7 +68,7 @@ var tooltipDecorator = function ( node, content ) {
 
   // Create some event handlers. NB we can use addEventListener
   // with impunity, even in old IE, by using a legacy build:
-  // https://docs.ractivejs.org/latest/Legacy-builds
+  // https://v0.x/latest/Legacy-builds
   handlers = {
     mouseover: function () {
       // Create a tooltip...

--- a/docs/0.3.9/Find plugins.md.hbs
+++ b/docs/0.3.9/Find plugins.md.hbs
@@ -7,7 +7,7 @@ Plugins allow you to augment Ractive with extra functionality. You can create yo
 
 ## {{{createLink 'Adaptors'}}}
 
-* [Backbone](http://ractivejs.org/examples/backbone)
+* [Backbone](http://ractive.js.org/examples/backbone)
 * [Promises](http://lluchs.github.io/Ractive-adaptors-Promise/) - contributed by [@lluchs](https://github.com/lluchs)
 * TODO Ractive (synchronise several Ractive instances)
 * TODO Object.observe

--- a/docs/0.3.9/Get started.md.hbs
+++ b/docs/0.3.9/Get started.md.hbs
@@ -4,8 +4,8 @@ title: Get started
 
 Welcome! These pages aim to provide all the information you need to master Ractive.
 
-If you see something wrong, out of date, or missing from this documentation, please [raise an issue on GitHub](https://github.com/ractivejs/docs.ractivejs.org/issues) or - even better - submit a pull request. Your fellow Ractive users will thank you!
+If you see something wrong, out of date, or missing from this documentation, please [raise an issue on GitHub](https://github.com/ractivejs/v0.x/issues) or - even better - submit a pull request. Your fellow Ractive users will thank you!
 
-A good way to get up and running is with the [60 second setup](http://ractivejs.org/60-second-setup). After that, working your way through the [interactive tutorials](http://learn.ractivejs.org) will familiarise you with the various ways you can use Ractive.
+A good way to get up and running is with the [60 second setup](http://ractive.js.org/60-second-setup). After that, working your way through the [interactive tutorials](http://learn.ractive.js.org) will familiarise you with the various ways you can use Ractive.
 
 If you get stuck at any point, visit the {{{createLink 'Get support'}}} page to find help.

--- a/docs/0.3.9/Initialisation options.md.hbs
+++ b/docs/0.3.9/Initialisation options.md.hbs
@@ -17,7 +17,7 @@ ractive = new Ractive({
 > ### **template** *`String` or (if {{{createLink 'preparsing'}}}) `Array` or `Object`*
 > The template to use. If this is a string, it must be valid (if meaningless, until rendered) HTML, otherwise this must be the output of {{{createLink 'Ractive.parse()'}}}.
 >
-> Alternatively, you can pass a string like `#myTemplate` - in this case, Ractive will use the contents of an element whose ID is `myTemplate`. See the [60 second setup](http://ractivejs.org/60-second-setup) for an example of this.
+> Alternatively, you can pass a string like `#myTemplate` - in this case, Ractive will use the contents of an element whose ID is `myTemplate`. See the [60 second setup](http://ractive.js.org/60-second-setup) for an example of this.
 
 
 ## Optional

--- a/docs/0.3.9/Mustaches.md.hbs
+++ b/docs/0.3.9/Mustaches.md.hbs
@@ -16,7 +16,7 @@ We say that the `\{{name}}` mustache has a *[reference](references)* of `name`. 
 
 As soon as the mustache knows what its keypath is (which may not be at render time, if data has not yet been set), it registers itself as a *{{{createLink 'dependants' 'depedant'}}}* of the keypath. Then, whenever data changes, Ractive scans the dependency graph to see which mustaches need to update, and notifies them accordingly.
 
-As well as simple *interpolators* like `\{{name}}`, the other mustaches types - sections, partials, and even delimiter changes - are supported. Consult the [tutorials](http://learn.ractivejs.org) to learn about these.
+As well as simple *interpolators* like `\{{name}}`, the other mustaches types - sections, partials, and even delimiter changes - are supported. Consult the [tutorials](http://learn.ractive.js.org) to learn about these.
 
 
 ## Extensions

--- a/docs/0.3.9/Plugins.md.hbs
+++ b/docs/0.3.9/Plugins.md.hbs
@@ -7,7 +7,7 @@ Plugins allow you to augment Ractive with extra functionality. You can create yo
 
 ## {{{createLink 'Adaptors'}}}
 
-* [Backbone](http://ractivejs.org/examples/backbone)
+* [Backbone](http://ractive.js.org/examples/backbone)
 * [Promises](http://lluchs.github.io/Ractive-adaptors-Promise/) - contributed by [@lluchs](https://github.com/lluchs)
 * TODO Ractive (synchronise several Ractive instances)
 * TODO Object.observe

--- a/docs/0.3.9/Using Ractive with Backbone.md.hbs
+++ b/docs/0.3.9/Using Ractive with Backbone.md.hbs
@@ -3,4 +3,4 @@ title: Using Ractive with Backbone
 ---
 If your app uses Backbone to manage your models and collections, you can use them seamlessly with Ractive by using an {{{createLink 'Ractive.adaptors' 'adaptor'}}}.
 
-[Download the Backbone adaptor here](https://github.com/RactiveJS/Ractive/blob/master/plugins/adaptors/Backbone.js), or see an [example](http://ractivejs.org/examples/backbone/).
+[Download the Backbone adaptor here](https://github.com/RactiveJS/Ractive/blob/master/plugins/adaptors/Backbone.js), or see an [example](http://ractive.js.org/examples/backbone/).

--- a/docs/0.4.0/Adaptors.md.hbs
+++ b/docs/0.4.0/Adaptors.md.hbs
@@ -4,7 +4,7 @@ title: Adaptors
 
 Adaptors are a way of teaching Ractive to communicate seamlessly with other libraries such as Backbone. This means that you can, for example, have some or all of your app's data handled by Backbone - including fetching from and saving to your server, validation, sorting, filtering and so on - but still build a reactive user interface using Ractive, without having to create custom View classes or adding a whole load of event binding code.
 
-It's probably easier to show, rather than tell: [this example application](http://examples.ractivejs.org/backbone) uses Backbone models describing all the James Bond films. The [code for the Backbone adaptor is here](https://github.com/ractivejs/ractive-adaptors-backbone).
+It's probably easier to show, rather than tell: [this example application](http://examples.ractive.js.org/backbone) uses Backbone models describing all the James Bond films. The [code for the Backbone adaptor is here](https://github.com/ractivejs/ractive-adaptors-backbone).
 
 
 Using adaptors

--- a/docs/0.4.0/Contributing.md.hbs
+++ b/docs/0.4.0/Contributing.md.hbs
@@ -10,7 +10,7 @@ Pull requests are always welcome on [GitHub](https://github.com/ractivejs/ractiv
 ## Other ways to contribute
 
 * Spread the word! The larger the community using Ractive, the better it becomes. Write blog posts, mention it to your developer colleagues and friends, submit talks (here are some [tips on speaking at tech meetups](http://speaking.io/)).
-* Fix documentation. Each page on this site has an 'edit' button in the top right, which will take you to GitHub where you can submit fixes. If you spot an error or think something's missing and aren't sure how to fix it, [raise an issue](https://github.com/ractivejs/docs.ractivejs.org/issues).
+* Fix documentation. Each page on this site has an 'edit' button in the top right, which will take you to GitHub where you can submit fixes. If you spot an error or think something's missing and aren't sure how to fix it, [raise an issue](https://github.com/ractivejs/v0.x/issues).
 * Help other developers on StackOverflow. Subscribe to [questions tagged 'ractivejs'](http://stackoverflow.com/questions/tagged/ractivejs), and you'll get alerts when someone asks a question that you might be able to answer.
 * Write plugins. See the {{{createLink 'Create plugins'}}} page for more information.
 

--- a/docs/0.4.0/Get started.md.hbs
+++ b/docs/0.4.0/Get started.md.hbs
@@ -4,9 +4,9 @@ title: Get started
 
 Welcome! These pages aim to provide all the information you need to master Ractive.
 
-If you see something wrong, out of date, or missing from this documentation, please [raise an issue on GitHub](https://github.com/ractivejs/docs.ractivejs.org/issues) or - even better - submit a pull request. Your fellow Ractive users will thank you!
+If you see something wrong, out of date, or missing from this documentation, please [raise an issue on GitHub](https://github.com/ractivejs/v0.x/issues) or - even better - submit a pull request. Your fellow Ractive users will thank you!
 
-A good way to get up and running is with the [60 second setup](http://ractivejs.org/60-second-setup). After that, working your way through the [interactive tutorials](http://learn.ractivejs.org) will familiarise you with the various ways you can use Ractive.
+A good way to get up and running is with the [60 second setup](http://ractive.js.org/60-second-setup). After that, working your way through the [interactive tutorials](http://learn.ractive.js.org) will familiarise you with the various ways you can use Ractive.
 
 If you get stuck at any point, visit the {{{createLink 'Get support'}}} page to find help.
 

--- a/docs/0.4.0/Initialisation options.md.hbs
+++ b/docs/0.4.0/Initialisation options.md.hbs
@@ -17,7 +17,7 @@ ractive = new Ractive({
 > ### **template** *`String` or (if {{{createLink 'preparsing'}}}) `Array` or `Object`*
 > The template to use. If this is a string, it must be valid (if meaningless, until rendered) HTML, otherwise this must be the output of {{{createLink 'Ractive.parse()'}}}.
 >
-> Alternatively, you can pass a string like `#myTemplate` - in this case, Ractive will use the contents of an element whose ID is `myTemplate`. See the [60 second setup](http://ractivejs.org/60-second-setup) for an example of this.
+> Alternatively, you can pass a string like `#myTemplate` - in this case, Ractive will use the contents of an element whose ID is `myTemplate`. See the [60 second setup](http://ractive.js.org/60-second-setup) for an example of this.
 
 
 ## Optional

--- a/docs/0.4.0/Legacy builds.md.hbs
+++ b/docs/0.4.0/Legacy builds.md.hbs
@@ -9,5 +9,5 @@ Fortunately, Ractive still caters for these browsers, but you need to use a lega
 
 You can find the builds here:
 
-* http://cdn.ractivejs.org/latest/ractive-legacy.js - last stable release
-* http://cdn.ractivejs.org/edge/ractive-legacy.js - most recent build
+* http://cdn.ractive.js.org/latest/ractive-legacy.js - last stable release
+* http://cdn.ractive.js.org/edge/ractive-legacy.js - most recent build

--- a/docs/0.4.0/Mustaches.md.hbs
+++ b/docs/0.4.0/Mustaches.md.hbs
@@ -16,7 +16,7 @@ We say that the `\{{name}}` mustache has a *[reference](references)* of `name`. 
 
 As soon as the mustache knows what its keypath is (which may not be at render time, if data has not yet been set), it registers itself as a *{{{createLink 'dependants' 'dependant'}}}* of the keypath. Then, whenever data changes, Ractive scans the dependency graph to see which mustaches need to update, and notifies them accordingly.
 
-As well as simple *interpolators* like `\{{name}}`, the other mustaches types - sections, partials, and even delimiter changes - are supported. Consult the [tutorials](http://learn.ractivejs.org) to learn about these.
+As well as simple *interpolators* like `\{{name}}`, the other mustaches types - sections, partials, and even delimiter changes - are supported. Consult the [tutorials](http://learn.ractive.js.org) to learn about these.
 
 
 ## Extensions

--- a/docs/0.4.0/Using Ractive with Backbone.md.hbs
+++ b/docs/0.4.0/Using Ractive with Backbone.md.hbs
@@ -3,4 +3,4 @@ title: Using Ractive with Backbone
 ---
 If your app uses Backbone to manage your models and collections, you can use them seamlessly with Ractive by using an {{{createLink 'Ractive.adaptors' 'adaptor'}}}.
 
-[Download the Backbone adaptor here](https://github.com/RactiveJS/Ractive/blob/master/plugins/adaptors/Backbone.js), or see an [example](http://ractivejs.org/examples/backbone/).
+[Download the Backbone adaptor here](https://github.com/RactiveJS/Ractive/blob/master/plugins/adaptors/Backbone.js), or see an [example](http://ractive.js.org/examples/backbone/).

--- a/docs/0.4.0/Writing decorator plugins.md.hbs
+++ b/docs/0.4.0/Writing decorator plugins.md.hbs
@@ -64,7 +64,7 @@ var tooltipDecorator = function ( node, content ) {
 
   // Create some event handlers. NB we can use addEventListener
   // with impunity, even in old IE, by using a legacy build:
-  // https://docs.ractivejs.org/latest/Legacy-builds
+  // https://v0.x/latest/Legacy-builds
   handlers = {
     mouseover: function () {
       // Create a tooltip...

--- a/docs/0.5/Adaptors.md.hbs
+++ b/docs/0.5/Adaptors.md.hbs
@@ -4,7 +4,7 @@ title: Adaptors
 
 Adaptors are a way of teaching Ractive to communicate seamlessly with other libraries such as Backbone. This means that you can, for example, have some or all of your app's data handled by Backbone - including fetching from and saving to your server, validation, sorting, filtering and so on - but still build a reactive user interface using Ractive, without having to create custom View classes or adding a whole load of event binding code.
 
-It's probably easier to show, rather than tell: [this example application](http://examples.ractivejs.org/backbone) uses Backbone models describing all the James Bond films. The [code for the Backbone adaptor is here](https://github.com/ractivejs/ractive-adaptors-backbone).
+It's probably easier to show, rather than tell: [this example application](http://examples.ractive.js.org/backbone) uses Backbone models describing all the James Bond films. The [code for the Backbone adaptor is here](https://github.com/ractivejs/ractive-adaptors-backbone).
 
 
 Using adaptors

--- a/docs/0.5/Contributing.md.hbs
+++ b/docs/0.5/Contributing.md.hbs
@@ -10,7 +10,7 @@ Pull requests are always welcome on [GitHub](https://github.com/ractivejs/ractiv
 ## Other ways to contribute
 
 * Spread the word! The larger the community using Ractive, the better it becomes. Write blog posts, mention it to your developer colleagues and friends, submit talks (here are some [tips on speaking at tech meetups](http://speaking.io/)).
-* Fix documentation. Each page on this site has an 'edit' button in the top right, which will take you to GitHub where you can submit fixes. If you spot an error or think something's missing and aren't sure how to fix it, [raise an issue](https://github.com/ractivejs/docs.ractivejs.org/issues).
+* Fix documentation. Each page on this site has an 'edit' button in the top right, which will take you to GitHub where you can submit fixes. If you spot an error or think something's missing and aren't sure how to fix it, [raise an issue](https://github.com/ractivejs/v0.x/issues).
 * Help other developers on StackOverflow. Subscribe to [questions tagged 'ractivejs'](http://stackoverflow.com/questions/tagged/ractivejs), and you'll get alerts when someone asks a question that you might be able to answer.
 * Write plugins. See the {{{createLink 'Create plugins'}}} page for more information.
 

--- a/docs/0.5/Get started.md.hbs
+++ b/docs/0.5/Get started.md.hbs
@@ -4,7 +4,7 @@ title: Get started
 
 Welcome! These pages aim to provide all the information you need to master Ractive.
 
-If you see something wrong, out of date, or missing from this documentation, please [raise an issue on GitHub](https://github.com/ractivejs/docs.ractivejs.org/issues) or - even better - submit a pull request. Your fellow Ractive users will thank you!
+If you see something wrong, out of date, or missing from this documentation, please [raise an issue on GitHub](https://github.com/ractivejs/v0.x/issues) or - even better - submit a pull request. Your fellow Ractive users will thank you!
 
 Using Ractive is very simple. An instance is created using `new Ractive({...})`
 with the desired options:
@@ -21,7 +21,7 @@ While there are no _required_ options, the three show above: __el__ement, __temp
 are the most common. They specify __what data__ to bind to __what template__ and __where__ it should be placed
 in the __html document__.
 
-A good way to get up and running is with the [60 second setup](http://ractivejs.org/60-second-setup). After that, working your way through the [interactive tutorials](http://learn.ractivejs.org) will familiarise you with the various ways you can use Ractive.
+A good way to get up and running is with the [60 second setup](http://ractive.js.org/60-second-setup). After that, working your way through the [interactive tutorials](http://learn.ractive.js.org) will familiarise you with the various ways you can use Ractive.
 
 Checkout the {{{createLink 'Options' 'Configuration Options'}}} to learn more about
 all the available options.

--- a/docs/0.5/Legacy builds.md.hbs
+++ b/docs/0.5/Legacy builds.md.hbs
@@ -9,5 +9,5 @@ Fortunately, Ractive still caters for these browsers, but you need to use a lega
 
 You can find the builds here:
 
-* http://cdn.ractivejs.org/latest/ractive-legacy.js - last stable release
-* http://cdn.ractivejs.org/edge/ractive-legacy.js - most recent build
+* http://cdn.ractive.js.org/latest/ractive-legacy.js - last stable release
+* http://cdn.ractive.js.org/edge/ractive-legacy.js - most recent build

--- a/docs/0.5/Mustaches.md.hbs
+++ b/docs/0.5/Mustaches.md.hbs
@@ -20,7 +20,7 @@ As soon as the mustache knows what its keypath is (which may not be at render ti
 
 If you already know Mustache, Ractive supports all the Mustache features - basic Mustache variables like `\{{name}}`, as well as sections, partials, and even delimiter changes. If you're already familiar with Mustache, skip to the Extensions section below.
 
-You can also check out the [tutorials](http://learn.ractivejs.org).
+You can also check out the [tutorials](http://learn.ractive.js.org).
 
 ### Variables
 

--- a/docs/0.5/Options.md.hbs
+++ b/docs/0.5/Options.md.hbs
@@ -59,7 +59,7 @@ The following is a complete list of initialisation options, with full descriptio
 > ```js
 > template: '#myTemplate'
 > ```
-> See the [60 second setup](http://ractivejs.org/60-second-setup) for an example of this.
+> See the [60 second setup](http://ractive.js.org/60-second-setup) for an example of this.
 
 > Please note that while Ractive will fetch any element by ID and use its content as the template, browsers may escape the contents of tags like `<div>` when initially rendered, leading to unexpected results in your template.
 

--- a/docs/0.5/Using Ractive with Backbone.md.hbs
+++ b/docs/0.5/Using Ractive with Backbone.md.hbs
@@ -3,4 +3,4 @@ title: Using Ractive with Backbone
 ---
 If your app uses Backbone to manage your models and collections, you can use them seamlessly with Ractive by using an {{{createLink 'Ractive.adaptors' 'adaptor'}}}.
 
-[Download the Backbone adaptor here](https://github.com/ractivejs/ractive-adaptors-backbone), or see an [example](http://examples.ractivejs.org/backbone).
+[Download the Backbone adaptor here](https://github.com/ractivejs/ractive-adaptors-backbone), or see an [example](http://examples.ractive.js.org/backbone).

--- a/docs/0.5/Writing decorator plugins.md.hbs
+++ b/docs/0.5/Writing decorator plugins.md.hbs
@@ -64,7 +64,7 @@ var tooltipDecorator = function ( node, content ) {
 
   // Create some event handlers. NB we can use addEventListener
   // with impunity, even in old IE, by using a legacy build:
-  // https://docs.ractivejs.org/latest/Legacy-builds
+  // https://v0.x/latest/Legacy-builds
   handlers = {
     mouseover: function () {
       // Create a tooltip...

--- a/docs/0.6/Adaptors.md.hbs
+++ b/docs/0.6/Adaptors.md.hbs
@@ -4,7 +4,7 @@ title: Adaptors
 
 Adaptors are a way of teaching Ractive to communicate seamlessly with other libraries such as Backbone. This means that you can, for example, have some or all of your app's data handled by Backbone - including fetching from and saving to your server, validation, sorting, filtering and so on - but still build a reactive user interface using Ractive, without having to create custom View classes or adding a whole load of event binding code.
 
-It's probably easier to show, rather than tell: [this example application](http://examples.ractivejs.org/backbone) uses Backbone models describing all the James Bond films. The [code for the Backbone adaptor is here](https://github.com/ractivejs/ractive-adaptors-backbone).
+It's probably easier to show, rather than tell: [this example application](http://examples.ractive.js.org/backbone) uses Backbone models describing all the James Bond films. The [code for the Backbone adaptor is here](https://github.com/ractivejs/ractive-adaptors-backbone).
 
 
 Using adaptors

--- a/docs/0.6/Contributing.md.hbs
+++ b/docs/0.6/Contributing.md.hbs
@@ -10,7 +10,7 @@ Pull requests are always welcome on [GitHub](https://github.com/ractivejs/ractiv
 ## Other ways to contribute
 
 * Spread the word! The larger the community using Ractive, the better it becomes. Write blog posts, mention it to your developer colleagues and friends, submit talks (here are some [tips on speaking at tech meetups](http://speaking.io/)).
-* Fix documentation. Each page on this site has an 'edit' button in the top right, which will take you to GitHub where you can submit fixes. If you spot an error or think something's missing and aren't sure how to fix it, [raise an issue](https://github.com/ractivejs/docs.ractivejs.org/issues).
+* Fix documentation. Each page on this site has an 'edit' button in the top right, which will take you to GitHub where you can submit fixes. If you spot an error or think something's missing and aren't sure how to fix it, [raise an issue](https://github.com/ractivejs/v0.x/issues).
 * Help other developers on StackOverflow. Subscribe to [questions tagged 'ractivejs'](http://stackoverflow.com/questions/tagged/ractivejs), and you'll get alerts when someone asks a question that you might be able to answer.
 * Write plugins. See the {{{createLink 'Create plugins'}}} page for more information.
 

--- a/docs/0.6/Get started.md.hbs
+++ b/docs/0.6/Get started.md.hbs
@@ -5,7 +5,7 @@ title: Get started
 
 Welcome! These pages aim to provide all the information you need to master Ractive.
 
-If you see something wrong, out of date, or missing from this documentation, please [raise an issue on GitHub](https://github.com/ractivejs/docs.ractivejs.org/issues) or - even better - submit a pull request. Your fellow Ractive users will thank you!
+If you see something wrong, out of date, or missing from this documentation, please [raise an issue on GitHub](https://github.com/ractivejs/v0.x/issues) or - even better - submit a pull request. Your fellow Ractive users will thank you!
 
 Using Ractive is very simple. An instance is created using `new Ractive({...})`
 with the desired options:
@@ -21,7 +21,7 @@ var ractive = new Ractive({
 While there are no _required_ options, the three shown above - __el__ement, __template__ and __data__ - are the most common. They specify __what data__ to bind to __what template__ and __where__ it should be placed
 in the __html document__.
 
-A good way to get up and running is with the [60 second setup](http://ractivejs.org/60-second-setup). After that, working your way through the [interactive tutorials](http://learn.ractivejs.org) will familiarise you with the various ways you can use Ractive.
+A good way to get up and running is with the [60 second setup](http://ractive.js.org/60-second-setup). After that, working your way through the [interactive tutorials](http://learn.ractive.js.org) will familiarise you with the various ways you can use Ractive.
 
 Checkout the {{{createLink 'Options' 'Configuration Options'}}} to learn more about
 all the available options.

--- a/docs/0.6/Legacy builds.md.hbs
+++ b/docs/0.6/Legacy builds.md.hbs
@@ -9,5 +9,5 @@ Fortunately, Ractive still caters for these browsers, but you need to use a lega
 
 You can find the builds here:
 
-* http://cdn.ractivejs.org/latest/ractive-legacy.js - last stable release
-* http://cdn.ractivejs.org/edge/ractive-legacy.js - most recent build
+* http://cdn.ractive.js.org/latest/ractive-legacy.js - last stable release
+* http://cdn.ractive.js.org/edge/ractive-legacy.js - most recent build

--- a/docs/0.6/Mustaches.md.hbs
+++ b/docs/0.6/Mustaches.md.hbs
@@ -40,7 +40,7 @@ As soon as the mustache knows what its keypath is (which may not be at render ti
 
 If you already know Mustache, Ractive supports all the Mustache features - basic Mustache variables like `\{{name}}`, as well as sections, partials, and even delimiter changes. If you're already familiar with Mustache, skip to the Extensions section below.
 
-You can also check out the [tutorials](http://learn.ractivejs.org).
+You can also check out the [tutorials](http://learn.ractive.js.org).
 
 <a name="variables"></a>
 ### Variables

--- a/docs/0.6/Options.md.hbs
+++ b/docs/0.6/Options.md.hbs
@@ -84,7 +84,7 @@ ractive.myMethod(); // triggers the alert
 > ```js
 > template: '#myTemplate'
 > ```
-> See the [60 second setup](http://ractivejs.org/60-second-setup) for an example of this.
+> See the [60 second setup](http://ractive.js.org/60-second-setup) for an example of this.
 
 > Make sure to set `type='text/ractive'` on the `<script>` tag or the browser will try and execute the contents as javascript and you'll get an exception. Some text editors will highlight `type='text/html'` as HTML, which can be useful and the browser will still ignore it for execution.
 

--- a/docs/0.6/Using Ractive with Backbone.md.hbs
+++ b/docs/0.6/Using Ractive with Backbone.md.hbs
@@ -3,4 +3,4 @@ title: Using Ractive with Backbone
 ---
 If your app uses Backbone to manage your models and collections, you can use them seamlessly with Ractive by using an {{{createLink 'Ractive.adaptors' 'adaptor'}}}.
 
-[Download the Backbone adaptor here](https://github.com/ractivejs/ractive-adaptors-backbone), or see an [example](http://examples.ractivejs.org/backbone).
+[Download the Backbone adaptor here](https://github.com/ractivejs/ractive-adaptors-backbone), or see an [example](http://examples.ractive.js.org/backbone).

--- a/docs/0.6/Writing decorator plugins.md.hbs
+++ b/docs/0.6/Writing decorator plugins.md.hbs
@@ -64,7 +64,7 @@ var tooltipDecorator = function ( node, content ) {
 
   // Create some event handlers. NB we can use addEventListener
   // with impunity, even in old IE, by using a legacy build:
-  // https://docs.ractivejs.org/latest/Legacy-builds
+  // https://v0.x/latest/Legacy-builds
   handlers = {
     mouseover: function () {
       // Create a tooltip...

--- a/docs/0.7/Adaptors.md.hbs
+++ b/docs/0.7/Adaptors.md.hbs
@@ -4,7 +4,7 @@ title: Adaptors
 
 Adaptors are a way of teaching Ractive to communicate seamlessly with other libraries such as Backbone. This means that you can, for example, have some or all of your app's data handled by Backbone - including fetching from and saving to your server, validation, sorting, filtering and so on - but still build a reactive user interface using Ractive, without having to create custom View classes or adding a whole load of event binding code.
 
-It's probably easier to show, rather than tell: [this example application](http://examples.ractivejs.org/backbone) uses Backbone models describing all the James Bond films. The [code for the Backbone adaptor is here](https://github.com/ractivejs/ractive-adaptors-backbone).
+It's probably easier to show, rather than tell: [this example application](http://examples.ractive.js.org/backbone) uses Backbone models describing all the James Bond films. The [code for the Backbone adaptor is here](https://github.com/ractivejs/ractive-adaptors-backbone).
 
 
 Using adaptors

--- a/docs/0.7/Components.md.hbs
+++ b/docs/0.7/Components.md.hbs
@@ -12,6 +12,10 @@ First, you need to **create the component** with {{{createLink 'Ractive.extend()
 * [The \{{yield}} Directive](#yield)
 * [Parents and Containers](#parent)
 
+## Minumum example
+
+<script async src="//jsfiddle.net/ceremcem/akhc6by6/embed/"></script>
+
 ## <a name="init"></a>Initialisation Options
 
 Most of the normal Ractive {{{ createLink 'options' 'initialisation options' }}} also apply to components, particularly the {{{ createLink 'lifecycle events' }}}, a few of which are listed here.

--- a/docs/0.7/Contributing.md.hbs
+++ b/docs/0.7/Contributing.md.hbs
@@ -10,7 +10,7 @@ Pull requests are always welcome on [GitHub](https://github.com/ractivejs/ractiv
 ## Other ways to contribute
 
 * Spread the word! The larger the community using Ractive, the better it becomes. Write blog posts, mention it to your developer colleagues and friends, submit talks (here are some [tips on speaking at tech meetups](http://speaking.io/)).
-* Fix documentation. Each page on this site has an 'edit' button in the top right, which will take you to GitHub where you can submit fixes. If you spot an error or think something's missing and aren't sure how to fix it, [raise an issue](https://github.com/ractivejs/docs.ractivejs.org/issues).
+* Fix documentation. Each page on this site has an 'edit' button in the top right, which will take you to GitHub where you can submit fixes. If you spot an error or think something's missing and aren't sure how to fix it, [raise an issue](https://github.com/ractivejs/v0.x/issues).
 * Help other developers on StackOverflow. Subscribe to [questions tagged 'ractivejs'](http://stackoverflow.com/questions/tagged/ractivejs), and you'll get alerts when someone asks a question that you might be able to answer.
 * Write plugins. See the {{{createLink 'Create plugins'}}} page for more information.
 

--- a/docs/0.7/Get started.md.hbs
+++ b/docs/0.7/Get started.md.hbs
@@ -4,7 +4,7 @@ title: Get started
 
 Welcome! These pages aim to provide all the information you need to master Ractive.
 
-If you see something wrong, out of date, or missing from this documentation, please check out our {{{createLink 'Known issues, FAQs, and Tips' 'known issues and FAQs'}}}, [raise an issue on GitHub](https://github.com/ractivejs/docs.ractivejs.org/issues) or - even better - submit a pull request. Your fellow Ractive users will thank you!
+If you see something wrong, out of date, or missing from this documentation, please check out our {{{createLink 'Known issues, FAQs, and Tips' 'known issues and FAQs'}}}, [raise an issue on GitHub](https://github.com/ractivejs/v0.x/issues) or - even better - submit a pull request. Your fellow Ractive users will thank you!
 
 Using Ractive is very simple. An instance is created using `new Ractive({...})`
 with the desired options:
@@ -20,7 +20,7 @@ var ractive = new Ractive({
 While there are no _required_ options, the three shown above - __el__ement, __template__ and __data__ - are the most common. They specify __what data__ to bind to __what template__ and __where__ it should be placed
 in the __html document__.
 
-A good way to get up and running is with the [60 second setup](http://ractivejs.org/60-second-setup). After that, working your way through the [interactive tutorials](http://learn.ractivejs.org) will familiarise you with the various ways you can use Ractive.
+A good way to get up and running is with the [60 second setup](http://ractive.js.org/60-second-setup). After that, working your way through the [interactive tutorials](http://learn.ractive.js.org) will familiarise you with the various ways you can use Ractive.
 
 Checkout the {{{createLink 'Options' 'Configuration Options'}}} to learn more about
 all the available options.

--- a/docs/0.7/Legacy builds.md.hbs
+++ b/docs/0.7/Legacy builds.md.hbs
@@ -9,5 +9,5 @@ Fortunately, Ractive still caters for these browsers, but you need to use a lega
 
 You can find the builds here:
 
-* http://cdn.ractivejs.org/latest/ractive-legacy.js - last stable release
-* http://cdn.ractivejs.org/edge/ractive-legacy.js - most recent build
+* http://cdn.ractive.js.org/latest/ractive-legacy.js - last stable release
+* http://cdn.ractive.js.org/edge/ractive-legacy.js - most recent build

--- a/docs/0.7/Mustaches.md.hbs
+++ b/docs/0.7/Mustaches.md.hbs
@@ -42,7 +42,7 @@ As soon as the mustache knows what its keypath is (which may not be at render ti
 
 If you already know Mustache, Ractive supports all the Mustache features - basic Mustache variables like `\{{name}}`, as well as sections, partials, and even delimiter changes. If you're already familiar with Mustache, skip to the Extensions section below.
 
-You can also check out the [tutorials](http://learn.ractivejs.org).
+You can also check out the [tutorials](http://learn.ractive.js.org).
 
 <a name="variables"></a>
 ### Variables

--- a/docs/0.7/Options.md.hbs
+++ b/docs/0.7/Options.md.hbs
@@ -83,7 +83,7 @@ ractive.myMethod(); // triggers the alert
 > ```js
 > template: '#myTemplate'
 > ```
-> See the [60 second setup](http://ractivejs.org/60-second-setup) for an example of this.
+> See the [60 second setup](http://ractive.js.org/60-second-setup) for an example of this.
 
 > Make sure to set `type='text/ractive'` on the `<script>` tag or the browser will try and execute the contents as javascript and you'll get an exception. Some text editors will highlight `type='text/html'` as HTML, which can be useful and the browser will still ignore it for execution.
 

--- a/docs/0.7/Using Ractive with Backbone.md.hbs
+++ b/docs/0.7/Using Ractive with Backbone.md.hbs
@@ -3,4 +3,4 @@ title: Using Ractive with Backbone
 ---
 If your app uses Backbone to manage your models and collections, you can use them seamlessly with Ractive by using an {{{createLink 'Ractive.adaptors' 'adaptor'}}}.
 
-[Download the Backbone adaptor here](https://github.com/ractivejs/ractive-adaptors-backbone), or <strike>see an [example](http://examples.ractivejs.org/backbone)</strike> *example will be reinstated soon!*.
+[Download the Backbone adaptor here](https://github.com/ractivejs/ractive-adaptors-backbone), or <strike>see an [example](http://examples.ractive.js.org/backbone)</strike> *example will be reinstated soon!*.

--- a/docs/0.7/Writing decorator plugins.md.hbs
+++ b/docs/0.7/Writing decorator plugins.md.hbs
@@ -64,7 +64,7 @@ var tooltipDecorator = function ( node, content ) {
 
   // Create some event handlers. NB we can use addEventListener
   // with impunity, even in old IE, by using a legacy build:
-  // https://docs.ractivejs.org/latest/Legacy-builds
+  // https://v0.x/latest/Legacy-builds
   handlers = {
     mouseover: function () {
       // Create a tooltip...

--- a/docs/edge/Adaptors.md.hbs
+++ b/docs/edge/Adaptors.md.hbs
@@ -4,7 +4,7 @@ title: Adaptors
 
 Adaptors are a way of teaching Ractive to communicate seamlessly with other libraries such as Backbone. This means that you can, for example, have some or all of your app's data handled by Backbone - including fetching from and saving to your server, validation, sorting, filtering and so on - but still build a reactive user interface using Ractive, without having to create custom View classes or adding a whole load of event binding code.
 
-It's probably easier to show, rather than tell: [this example application](http://examples.ractivejs.org/backbone) uses Backbone models describing all the James Bond films. The [code for the Backbone adaptor is here](https://github.com/ractivejs/ractive-adaptors-backbone).
+It's probably easier to show, rather than tell: [this example application](http://examples.ractive.js.org/backbone) uses Backbone models describing all the James Bond films. The [code for the Backbone adaptor is here](https://github.com/ractivejs/ractive-adaptors-backbone).
 
 
 Using adaptors

--- a/docs/edge/Contributing.md.hbs
+++ b/docs/edge/Contributing.md.hbs
@@ -10,7 +10,7 @@ Pull requests are always welcome on [GitHub](https://github.com/ractivejs/ractiv
 ## Other ways to contribute
 
 * Spread the word! The larger the community using Ractive, the better it becomes. Write blog posts, mention it to your developer colleagues and friends, submit talks (here are some [tips on speaking at tech meetups](http://speaking.io/)).
-* Fix documentation. Each page on this site has an 'edit' button in the top right, which will take you to GitHub where you can submit fixes. If you spot an error or think something's missing and aren't sure how to fix it, [raise an issue](https://github.com/ractivejs/docs.ractivejs.org/issues).
+* Fix documentation. Each page on this site has an 'edit' button in the top right, which will take you to GitHub where you can submit fixes. If you spot an error or think something's missing and aren't sure how to fix it, [raise an issue](https://github.com/ractivejs/v0.x/issues).
 * Help other developers on StackOverflow. Subscribe to [questions tagged 'ractivejs'](http://stackoverflow.com/questions/tagged/ractivejs), and you'll get alerts when someone asks a question that you might be able to answer.
 * Write plugins. See the {{{createLink 'Create plugins'}}} page for more information.
 

--- a/docs/edge/Get started.md.hbs
+++ b/docs/edge/Get started.md.hbs
@@ -4,7 +4,7 @@ title: Get started
 
 Welcome! These pages aim to provide all the information you need to master Ractive.
 
-If you see something wrong, out of date, or missing from this documentation, please check out our {{{createLink 'Known issues, FAQs, and Tips' 'known issues and FAQs'}}}, [raise an issue on GitHub](https://github.com/ractivejs/docs.ractivejs.org/issues) or - even better - submit a pull request. Your fellow Ractive users will thank you!
+If you see something wrong, out of date, or missing from this documentation, please check out our {{{createLink 'Known issues, FAQs, and Tips' 'known issues and FAQs'}}}, [raise an issue on GitHub](https://github.com/ractivejs/v0.x/issues) or - even better - submit a pull request. Your fellow Ractive users will thank you!
 
 Using Ractive is very simple. An instance is created using `new Ractive({...})`
 with the desired options:
@@ -20,7 +20,7 @@ var ractive = new Ractive({
 While there are no _required_ options, the three shown above - __el__ement, __template__ and __data__ - are the most common. They specify __what data__ to bind to __what template__ and __where__ it should be placed
 in the __html document__.
 
-A good way to get up and running is with the [60 second setup](http://ractivejs.org/60-second-setup). After that, working your way through the [interactive tutorials](http://learn.ractivejs.org) will familiarise you with the various ways you can use Ractive.
+A good way to get up and running is with the [60 second setup](http://ractive.js.org/60-second-setup). After that, working your way through the [interactive tutorials](http://learn.ractive.js.org) will familiarise you with the various ways you can use Ractive.
 
 Checkout the {{{createLink 'Options' 'Configuration Options'}}} to learn more about
 all the available options.

--- a/docs/edge/Legacy builds.md.hbs
+++ b/docs/edge/Legacy builds.md.hbs
@@ -9,5 +9,5 @@ Fortunately, Ractive still caters for these browsers, but you need to use a lega
 
 You can find the builds here:
 
-* http://cdn.ractivejs.org/latest/ractive-legacy.js - last stable release
-* http://cdn.ractivejs.org/edge/ractive-legacy.js - most recent build
+* http://cdn.ractive.js.org/latest/ractive-legacy.js - last stable release
+* http://cdn.ractive.js.org/edge/ractive-legacy.js - most recent build

--- a/docs/edge/Mustaches.md.hbs
+++ b/docs/edge/Mustaches.md.hbs
@@ -42,7 +42,7 @@ As soon as the mustache knows what its keypath is (which may not be at render ti
 
 If you already know Mustache, Ractive supports all the Mustache features - basic Mustache variables like `\{{name}}`, as well as sections, partials, and even delimiter changes. If you're already familiar with Mustache, skip to the Extensions section below.
 
-You can also check out the [tutorials](http://learn.ractivejs.org).
+You can also check out the [tutorials](http://learn.ractive.js.org).
 
 <a name="variables"></a>
 ### Variables

--- a/docs/edge/Options.md.hbs
+++ b/docs/edge/Options.md.hbs
@@ -83,7 +83,7 @@ ractive.myMethod(); // triggers the alert
 > ```js
 > template: '#myTemplate'
 > ```
-> See the [60 second setup](http://ractivejs.org/60-second-setup) for an example of this.
+> See the [60 second setup](http://ractive.js.org/60-second-setup) for an example of this.
 
 > Make sure to set `type='text/ractive'` on the `<script>` tag or the browser will try and execute the contents as javascript and you'll get an exception. Some text editors will highlight `type='text/html'` as HTML, which can be useful and the browser will still ignore it for execution.
 

--- a/docs/edge/Using Ractive with Backbone.md.hbs
+++ b/docs/edge/Using Ractive with Backbone.md.hbs
@@ -3,4 +3,4 @@ title: Using Ractive with Backbone
 ---
 If your app uses Backbone to manage your models and collections, you can use them seamlessly with Ractive by using an {{{createLink 'Ractive.adaptors' 'adaptor'}}}.
 
-[Download the Backbone adaptor here](https://github.com/ractivejs/ractive-adaptors-backbone), or see an [example](http://examples.ractivejs.org/backbone).
+[Download the Backbone adaptor here](https://github.com/ractivejs/ractive-adaptors-backbone), or see an [example](http://examples.ractive.js.org/backbone).

--- a/docs/edge/Writing decorator plugins.md.hbs
+++ b/docs/edge/Writing decorator plugins.md.hbs
@@ -64,7 +64,7 @@ var tooltipDecorator = function ( node, content ) {
 
   // Create some event handlers. NB we can use addEventListener
   // with impunity, even in old IE, by using a legacy build:
-  // https://docs.ractivejs.org/latest/Legacy-builds
+  // https://v0.x/latest/Legacy-builds
   handlers = {
     mouseover: function () {
       // Create a tooltip...

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "docs.ractivejs.org",
+  "name": "v0.x",
   "author": "Rich Harris",
   "version": "0.8.0",
   "devDependencies": {
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "grunt build",
     "predeploy": "npm run build",
-    "deploy": "surge build docs.ractivejs.org",
+    "deploy": "surge build v0.x",
     "grunt": "./node_modules/.bin/grunt"
   }
 }

--- a/root/CNAME
+++ b/root/CNAME
@@ -1,1 +1,1 @@
-docs.ractivejs.org
+v0.x

--- a/shared/partials/nav.html
+++ b/shared/partials/nav.html
@@ -1,14 +1,14 @@
 <nav>
 	<div class='nav-inner'>
-		<a<%= id === 'index' ? ' class="selected"' : '' %> href='http://ractivejs.org'>Ractive.js</a>
+		<a<%= id === 'index' ? ' class="selected"' : '' %> href='http://ractive.js.org'>Ractive.js</a>
 
 		<ul>
-			<li<%= id === 'setup'    ? ' class="selected"' : '' %>><a href='http://ractivejs.org/60-second-setup'>60 second setup</a></li>
-			<li<%= id === 'learn'    ? ' class="selected"' : '' %>><a href='http://learn.ractivejs.org'>Tutorials</a></li>
-			<li<%= id === 'examples' ? ' class="selected"' : '' %>><a href='http://examples.ractivejs.org'>Examples</a></li>
-			<li<%= id === 'docs'     ? ' class="selected"' : '' %>><a href='http://docs.ractivejs.org'>Docs</a></li>
-			<li<%= id === 'plugins'  ? ' class="selected"' : '' %>><a href='http://docs.ractivejs.org/latest/plugins'>Plugins</a></li>
-			<li<%= id === 'blog'     ? ' class="selected"' : '' %>><a href='http://blog.ractivejs.org'>Blog</a></li>
+			<li<%= id === 'setup'    ? ' class="selected"' : '' %>><a href='http://ractive.js.org/60-second-setup'>60 second setup</a></li>
+			<li<%= id === 'learn'    ? ' class="selected"' : '' %>><a href='http://learn.ractive.js.org'>Tutorials</a></li>
+			<li<%= id === 'examples' ? ' class="selected"' : '' %>><a href='http://examples.ractive.js.org'>Examples</a></li>
+			<li<%= id === 'docs'     ? ' class="selected"' : '' %>><a href='http://v0.x'>Docs</a></li>
+			<li<%= id === 'plugins'  ? ' class="selected"' : '' %>><a href='http://v0.x/latest/plugins'>Plugins</a></li>
+			<li<%= id === 'blog'     ? ' class="selected"' : '' %>><a href='http://blog.ractive.js.org'>Blog</a></li>
 			<li class='github-small'><a href='https://github.com/ractivejs/ractive'>GitHub</a></li>
 		</ul>
 

--- a/templates/0.3.9/page.hbs
+++ b/templates/0.3.9/page.hbs
@@ -41,7 +41,7 @@
 
 	<%= footer %>
 
-	<%= analytics("UA-5602942-6","ractivejs.org") %>
+	<%= analytics("UA-5602942-6","ractive.js.org") %>
 
 	<script src='../assets/nav.js'></script>
 

--- a/templates/0.3.9/partials/header.hbs
+++ b/templates/0.3.9/partials/header.hbs
@@ -4,10 +4,10 @@
 </div>
 
 <ul class="menu">
-	<li><a href="http://ractivejs.org">Home</a></li>
-	<li><a href="http://blog.ractivejs.org">Blog</a></li>
-	<li><a href="http://learn.ractivejs.org">Tutorials</a></li>
-	<li><a href="http://examples.ractivejs.org">Examples</a></li>
+	<li><a href="http://ractive.js.org">Home</a></li>
+	<li><a href="http://blog.ractive.js.org">Blog</a></li>
+	<li><a href="http://learn.ractive.js.org">Tutorials</a></li>
+	<li><a href="http://examples.ractive.js.org">Examples</a></li>
 	<li><a href="plugins">Plugins</a></li>
 	<li>Docs</li>
 	<li><a href="download">Download</a></li>

--- a/templates/0.4.0/page.hbs
+++ b/templates/0.4.0/page.hbs
@@ -41,7 +41,7 @@
 
 	<%= footer %>
 
-	<%= analytics("UA-5602942-6","ractivejs.org") %>
+	<%= analytics("UA-5602942-6","ractive.js.org") %>
 
 	<script src='../assets/nav.js'></script>
 

--- a/templates/0.4.0/partials/header.hbs
+++ b/templates/0.4.0/partials/header.hbs
@@ -4,10 +4,10 @@
 </div>
 
 <ul class="menu">
-	<li><a href="http://ractivejs.org">Home</a></li>
-	<li><a href="http://blog.ractivejs.org">Blog</a></li>
-	<li><a href="http://learn.ractivejs.org">Tutorials</a></li>
-	<li><a href="http://examples.ractivejs.org">Examples</a></li>
+	<li><a href="http://ractive.js.org">Home</a></li>
+	<li><a href="http://blog.ractive.js.org">Blog</a></li>
+	<li><a href="http://learn.ractive.js.org">Tutorials</a></li>
+	<li><a href="http://examples.ractive.js.org">Examples</a></li>
 	<li><a href="plugins">Plugins</a></li>
 	<li>Docs</li>
 	<li><a href="download">Download</a></li>

--- a/templates/0.5/page.hbs
+++ b/templates/0.5/page.hbs
@@ -41,7 +41,7 @@
 
 	<%= footer %>
 
-	<%= analytics("UA-5602942-6","ractivejs.org") %>
+	<%= analytics("UA-5602942-6","ractive.js.org") %>
 
 	<script src='../assets/nav.js'></script>
 

--- a/templates/0.5/partials/header.hbs
+++ b/templates/0.5/partials/header.hbs
@@ -4,10 +4,10 @@
 </div>
 
 <ul class="menu">
-	<li><a href="http://ractivejs.org">Home</a></li>
-	<li><a href="http://blog.ractivejs.org">Blog</a></li>
-	<li><a href="http://learn.ractivejs.org">Tutorials</a></li>
-	<li><a href="http://examples.ractivejs.org">Examples</a></li>
+	<li><a href="http://ractive.js.org">Home</a></li>
+	<li><a href="http://blog.ractive.js.org">Blog</a></li>
+	<li><a href="http://learn.ractive.js.org">Tutorials</a></li>
+	<li><a href="http://examples.ractive.js.org">Examples</a></li>
 	<li><a href="plugins">Plugins</a></li>
 	<li>Docs</li>
 	<li><a href="download">Download</a></li>

--- a/templates/0.6/page.hbs
+++ b/templates/0.6/page.hbs
@@ -41,7 +41,7 @@
 
 	<%= footer %>
 
-	<%= analytics("UA-5602942-6","ractivejs.org") %>
+	<%= analytics("UA-5602942-6","ractive.js.org") %>
 
 	<script src='../assets/nav.js'></script>
 

--- a/templates/0.6/partials/header.hbs
+++ b/templates/0.6/partials/header.hbs
@@ -4,10 +4,10 @@
 </div>
 
 <ul class="menu">
-	<li><a href="http://ractivejs.org">Home</a></li>
-	<li><a href="http://blog.ractivejs.org">Blog</a></li>
-	<li><a href="http://learn.ractivejs.org">Tutorials</a></li>
-	<li><a href="http://examples.ractivejs.org">Examples</a></li>
+	<li><a href="http://ractive.js.org">Home</a></li>
+	<li><a href="http://blog.ractive.js.org">Blog</a></li>
+	<li><a href="http://learn.ractive.js.org">Tutorials</a></li>
+	<li><a href="http://examples.ractive.js.org">Examples</a></li>
 	<li><a href="plugins">Plugins</a></li>
 	<li>Docs</li>
 	<li><a href="download">Download</a></li>

--- a/templates/0.7/page.hbs
+++ b/templates/0.7/page.hbs
@@ -41,7 +41,7 @@
 
 	<%= footer %>
 
-	<%= analytics("UA-5602942-6","ractivejs.org") %>
+	<%= analytics("UA-5602942-6","ractive.js.org") %>
 
 	<script src='../assets/nav.js'></script>
 

--- a/templates/0.7/partials/header.hbs
+++ b/templates/0.7/partials/header.hbs
@@ -4,10 +4,10 @@
 </div>
 
 <ul class="menu">
-	<li><a href="http://ractivejs.org">Home</a></li>
-	<li><a href="http://blog.ractivejs.org">Blog</a></li>
-	<li><a href="http://learn.ractivejs.org">Tutorials</a></li>
-	<li><a href="http://examples.ractivejs.org">Examples</a></li>
+	<li><a href="http://ractive.js.org">Home</a></li>
+	<li><a href="http://blog.ractive.js.org">Blog</a></li>
+	<li><a href="http://learn.ractive.js.org">Tutorials</a></li>
+	<li><a href="http://examples.ractive.js.org">Examples</a></li>
 	<li><a href="plugins">Plugins</a></li>
 	<li>Docs</li>
 	<li><a href="download">Download</a></li>

--- a/templates/edge/page.hbs
+++ b/templates/edge/page.hbs
@@ -41,7 +41,7 @@
 
 	<%= footer %>
 
-	<%= analytics("UA-5602942-6","ractivejs.org") %>
+	<%= analytics("UA-5602942-6","ractive.js.org") %>
 
 	<script src='../assets/nav.js'></script>
 

--- a/templates/edge/partials/header.hbs
+++ b/templates/edge/partials/header.hbs
@@ -4,10 +4,10 @@
 </div>
 
 <ul class="menu">
-	<li><a href="http://ractivejs.org">Home</a></li>
-	<li><a href="http://blog.ractivejs.org">Blog</a></li>
-	<li><a href="http://learn.ractivejs.org">Tutorials</a></li>
-	<li><a href="http://examples.ractivejs.org">Examples</a></li>
+	<li><a href="http://ractive.js.org">Home</a></li>
+	<li><a href="http://blog.ractive.js.org">Blog</a></li>
+	<li><a href="http://learn.ractive.js.org">Tutorials</a></li>
+	<li><a href="http://examples.ractive.js.org">Examples</a></li>
 	<li><a href="plugins">Plugins</a></li>
 	<li>Docs</li>
 	<li><a href="download">Download</a></li>


### PR DESCRIPTION
Live example is added for minimum component declaration, regarding to https://github.com/ractivejs/docs.ractivejs.org/issues/261

**NOTE**: The added line is not tested 
