### PR TITLE
Fixes misses closing '/' in component declaration

### DIFF
--- a/docs/0.8/Components.md.hbs
+++ b/docs/0.8/Components.md.hbs
@@ -69,7 +69,7 @@ var ractive = new Ractive({
 
 <script id="template" type="text/ractive">
   <div>
-    <Component>
+    <Component/>
   </div>
 </script>
 


### PR DESCRIPTION
The component declaration 'Component' is missing a now-required '/' on the tag.  As is stands the example fails.

Is there not a better way of ensuring that documentation samples stay up-to-date and correct?  As it's the first port-of-call for people learning a feature, if the examples are wrong, it doesn't create a good experience, especially as one assumes that one's own code is wrong, rather than the example.

Maybe embed a fiddle instead of the raw code?  Then this can be easily tested on each new release.