### PR TITLE
Fix wrong link

### DIFF
--- a/docs/0.8/ractive.update().md.hbs
+++ b/docs/0.8/ractive.update().md.hbs
@@ -2,7 +2,7 @@
 title: ractive.update()
 ---
 
-Forces everything that depends on the specified {{{createLink 'keypath' 'keypaths'}}} (whether directly or indirectly) to be 'dirty checked'. This is useful if you manipulate data without using the built in setter methods (i.e. {{{createLink 'ractive.set()'}}}, {{{createLink 'ractive.animate()'}}}, or {{{createLink 'array modification' 'array modification'}}}):
+Forces everything that depends on the specified {{{createLink 'keypaths' 'keypaths'}}} (whether directly or indirectly) to be 'dirty checked'. This is useful if you manipulate data without using the built in setter methods (i.e. {{{createLink 'ractive.set()'}}}, {{{createLink 'ractive.animate()'}}}, or {{{createLink 'array modification' 'array modification'}}}):
 
 ```js
 ractive.observe( 'foo', function ( foo ) {


### PR DESCRIPTION
On this [page](https://ractive.js.org/v0.x/0.8/ractive-update), the 'keypaths' link redirects to _ractive.js.org/v0.x/0.8/keypath_, which is inexistant. 

The right link is _ractive.js.org/v0.x/0.8/keypath**s**_